### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 * [WeUI](https://github.com/KuangPF/wxapp-vue) - 用 vue 写小程序，基于 mpvue 框架重写 weui。
 * [mpvue-zanui](https://github.com/samwang1027/mpvue-zanui) - 使用 mpvue 框架重写 zanui。
 * [mp-weui](https://github.com/youngluo/mp-weui) - 基于 mpvue 和 weui-wxss 封装的小程序UI库。
+* [mpvue-simple-cli](https://github.com/spencer1994/mpvue-cli) - 基于 mpvue 及一些基础工具封装的简单cli。
 
 ## 组件
 
@@ -51,3 +52,4 @@
 
 * [quickstart](https://github.com/mpvue/mpvue-quickstart) - quickstart
 * [webpack-mpvue-startup](https://github.com/dwqs/webpack-mpvue-startup) - Webpack 3 + Mpvue 1
+


### PR DESCRIPTION
按自己对vue的理解以及mpvue相关贡献者的帮助下，写了个mpvue的简单cli。其中包括了如下几点：

1.通过使用[F-loat的mpvue-entry](https://github.com/F-loat/mpvue-entry)去除了官方子页面的main.js。

2.通过webpack的require.context及[vuex的registerModules](https://vuex.vuejs.org/zh-cn/api.html)完成了自动注册store的功能。

3.根据vuex的[background API规范](https://vuex.vuejs.org/zh-cn/intro.html)封装了flyio接口请求方法。

浅薄贡献，希望能帮助开发者少走弯路。