### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 * [minapp-api-promise](https://github.com/bigmeow/minapp-api-promise) - 将所有异步微信小程序API promise化，支持then/catch、async/await的方式调用小程序API;支持请求队列，支持对原生API进行拦截。
 * [mpvue-entry](https://github.com/F-loat/mpvue-entry) - 集中式页面配置，避免重复编辑各页面的 main.js 文件，优化目录结构。
 * [mpvue-router-patch](https://github.com/F-loat/mpvue-router-patch) - 在 mpvue 中使用 vue-router 兼容的路由写法。
+* [mpvue-simple-cli](https://github.com/spencer1994/mpvue-cli) - 对官方模版进行改造，使得开发更接近于vue的风格。
 
 ## 框架
 


### PR DESCRIPTION
按自己对vue的理解以及mpvue相关贡献者的帮助下，写了个mpvue的简单cli。其中包括了如下几点：

1.通过使用[F-loat的mpvue-entry](https://github.com/F-loat/mpvue-entry)去除了官方子页面的main.js。

2.通过webpack的require.context及[vuex的registerModules](https://vuex.vuejs.org/zh-cn/api.html)完成了自动注册store的功能。

3.根据vuex的[background API规范](https://vuex.vuejs.org/zh-cn/intro.html)封装了flyio接口请求方法。

浅薄贡献，希望能帮助开发者少走弯路。